### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ streamlit run .\app.py
 
 ## Reference
 
-- Style for my wep app: https://share.streamlit.io/streamlit/example-app-bert-keyword-extractor/main/app.py
+- Style for my web app: https://share.streamlit.io/streamlit/example-app-bert-keyword-extractor/main/app.py
 
 ## Utils
 


### PR DESCRIPTION
## Summary
- correct wording for the reference section in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68793566e1188326be230392e15ccf51